### PR TITLE
Fix ip-sticky example hanging

### DIFF
--- a/ip-sticky/server.js
+++ b/ip-sticky/server.js
@@ -27,7 +27,7 @@ if (cluster.isPrimary) {
     if (worker) worker.send({ name: 'socket' }, socket);
   };
 
-  const server = new net.Server(balancer);
+  const server = new net.Server({ pauseOnConnect: true }, balancer);
   server.listen(2000);
 } else {
   console.log(`Worker pid: ${process.pid}`);
@@ -45,6 +45,7 @@ if (cluster.isPrimary) {
     if (message.name === 'socket') {
       socket.server = server;
       server.emit('connection', socket);
+      socket.resume();
     }
   });
 }


### PR DESCRIPTION
To prevent master process reading from socket which cause hanging we have to pause connection and manually resume when child_process will be ready to process it.

Mentions in Node.js documentation here [net.createServer](https://nodejs.org/api/net.html#netcreateserveroptions-connectionlistener)

> If pauseOnConnect is set to true, then the socket associated with each incoming connection will be  
> paused, and no data will be read from its handle. This allows connections to be passed between 
> processes without any data being read by the original process.  
> To begin reading data from a paused socket, call `socket.resume()`.  
 

The issue resolved with a help of following issue: https://github.com/nodejs/node/issues/13435